### PR TITLE
Allow UI build without gstreamer-video

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -359,7 +359,11 @@ if test x$try_ui = xyes ; then
                           [$RYGEL_COMMON_MODULES gio-2.0 >= $GIO_REQUIRED
                            gssdp-1.0 >= $GSSDP_REQUIRED
                            gstreamer-video-1.0 >= $GSTREAMER_REQUIRED
-                           gtk+-3.0 >= $GTK_REQUIRED])
+                           gtk+-3.0 >= $GTK_REQUIRED],,
+                          [
+                           AC_MSG_WARN([Example UI dependencies not found.])
+                           AC_MSG_WARN([Example UI applications will not be built.])
+                          ])
       ],
       [
         AC_MSG_WARN([UI dependencies not found.])


### PR DESCRIPTION
If EXAMPLE_UI dependencies are not met, only display a warning instead
of ending configure with an error.
Indeed, currently, we can't build rygel UI without gstreamer-video which
is only a dependency of fullscreen-renderer application.

fullscreen-renderer won't be build without gstreamer as HAVE_GSTREAMER
has to be true to check HAVE_UI in examples/Makefile.am

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>