### PR TITLE
Add rygel@.service

### DIFF
--- a/examples/service/systemd/rygel.service
+++ b/examples/service/systemd/rygel.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Rygel DLNA server
-After=syslog.target
+After=network.target
 
 [Service]
 User=rygel

--- a/examples/service/systemd/rygel@.service
+++ b/examples/service/systemd/rygel@.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Rygel DLNA server
+Documentation=man:rygel(1)
+After=network.target
+
+[Service]
+User=%i
+ExecStart=/usr/bin/rygel
+Restart=on-failure
+
+# Hardening
+ProtectSystem=full
+PrivateTmp=true
+SystemCallArchitectures=native
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Useful on a no-gui system and most users will run it under their own user anyway. :)
I assume `network.target` should be needed instead of `syslog.target` - as it needs a network to operate?

Let me know if this is correct and/or things have to be changed.